### PR TITLE
Add next parameter for logout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+0.3.6 (2019-08-18)
+------------------
+* Feature: Allow redirect to be specified on logout
+
 0.3.5 (2019-08-18)
 ------------------
 * Fix: Callback when multiple redirect_uris are defined

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -52,4 +52,4 @@ class CallbackView(View):
 class LogoutView(View):
     def get(self, request):
         auth.logout(request)
-        return redirect('/')
+        return redirect(request.GET.get('next', '/'))

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -97,3 +97,8 @@ class LogoutViewTestCase(TestCase):
         response = self.client.get(reverse('accounts:logout'))
         sample_response = '/'
         self.assertRedirects(response, sample_response, fetch_redirect_response=False)
+
+    def test_redirect(self):
+        response = self.client.get(reverse('accounts:logout') + '?next=http://example.com')
+        sample_response = 'http://example.com'
+        self.assertRedirects(response, sample_response, fetch_redirect_response=False)


### PR DESCRIPTION
- Small change to add next parameter for logout. Use case is may want to redirect back to frontend after a logout has been completed.