### PR TITLE
PennID Migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+0.4.0 (UNRELEASED)
+------------------
+* Feature: Transition to PennIDs for authentication
+
 0.3.8 (2019-10-20)
 ------------------
 * Fix: Use POST in introspect call

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog
 0.4.0 (UNRELEASED)
 ------------------
 * Feature: Transition to PennIDs for authentication
+* Feature: Add additional method to run after user authentication
 
 0.3.8 (2019-10-20)
 ------------------

--- a/README.md
+++ b/README.md
@@ -82,6 +82,27 @@ When developing locally with an http (not https) callback URL, it may be helpful
 os.environ['OAUTHLIB_INSECURE_TRANSPORT'] = "1"
 ```
 
+## Custom post authentication
+
+If you want to customize how DLA saves user information from platform into User objects, you can subclass `accounts.backends.LabsUserBackend` and redefine the post_authenticate method. This method will be run after the user is logged in. The parameters are:
+
+* `user` the user object
+* `created` a boolean delineating if the user was just created
+* `dictionary` a dictionary of user information from platform.
+
+Then just set the `AUTHENTICATION_BACKENDS` setting to be the subclassed backend.
+
+Here is an example of a custom backend that sets every user's first name to `"Modified"`.
+
+```python
+from accounts.backends import LabsUserBackend
+
+class CustomBackend(LabsUserBackend):
+    def post_authenticate(self, user, created, dictionary):
+        user.first_name = 'Modified'
+        user.save()
+```
+
 ## Changelog
 
 See [CHANGELOG.md](https://github.com/pennlabs/django-labs-accounts/blob/master/CHANGELOG.md)

--- a/accounts/backends.py
+++ b/accounts/backends.py
@@ -6,6 +6,10 @@ from accounts.settings import accounts_settings
 
 class LabsUserBackend(RemoteUserBackend):
     def authenticate(self, request, remote_user):
+        """
+        Authenticate a user given a dictionary of user information from
+        platform.
+        """
         if not remote_user:
             return
         User = get_user_model()
@@ -29,4 +33,14 @@ class LabsUserBackend(RemoteUserBackend):
             user.is_superuser = True
 
         user.save()
+        self.post_authenticate(user, created)
         return user if self.user_can_authenticate(user) else None
+
+    def post_authenticate(self, user, created):
+        """
+        Post Authentication method that is run after logging in a user.
+        This allows products to add custom configuration by subclassing
+        LabsUserBackend and modifying this method.
+        By default this does nothing.
+        """
+        pass

--- a/accounts/backends.py
+++ b/accounts/backends.py
@@ -13,7 +13,10 @@ class LabsUserBackend(RemoteUserBackend):
         if not remote_user:
             return
         User = get_user_model()
-        user, created = User.objects.get_or_create(id=remote_user['pennid'])
+        user, created = User.objects.get_or_create(
+            id=remote_user['pennid'],
+            defaults={'username': remote_user['username']}
+        )
 
         if created:
             user.set_unusable_password()

--- a/accounts/backends.py
+++ b/accounts/backends.py
@@ -36,10 +36,10 @@ class LabsUserBackend(RemoteUserBackend):
             user.is_superuser = True
 
         user.save()
-        self.post_authenticate(user, created)
+        self.post_authenticate(user, created, remote_user)
         return user if self.user_can_authenticate(user) else None
 
-    def post_authenticate(self, user, created):
+    def post_authenticate(self, user, created, dictionary):
         """
         Post Authentication method that is run after logging in a user.
         This allows products to add custom configuration by subclassing

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -42,6 +42,7 @@ class CallbackView(View):
         access_token = token['access_token']
         introspect_url = accounts_settings.PLATFORM_URL + '/accounts/introspect/'
         user_props = platform.post(introspect_url, data={'token': access_token}).json()['user']
+        user_props['pennid'] = int(user_props['pennid'])
         user = auth.authenticate(request, remote_user=user_props)
         if user:
             auth.login(request, user)

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -7,8 +7,7 @@ class BackendTestCase(TestCase):
     def setUp(self):
         self.User = get_user_model()
         self.remote_user = {
-            'major': 'Major',
-            'school': 'School',
+            'pennid': '1',
             'first_name': 'First',
             'last_name': 'Last',
             'username': 'user',
@@ -31,8 +30,17 @@ class BackendTestCase(TestCase):
         self.assertEqual(user.email, 'test@test.com')
         self.assertFalse(self.User.objects.all()[0].is_staff)
 
+    def test_update_user(self):
+        auth.authenticate(remote_user=self.remote_user)
+        self.assertEqual(len(self.User.objects.all()), 1)
+        self.remote_user['username'] = 'changed_user'
+        auth.authenticate(remote_user=self.remote_user)
+        user = self.User.objects.all()[0]
+        self.assertEqual(user.username, 'changed_user')
+
     def test_login_user(self):
         student = self.User.objects.create_user(
+            id=1,
             username='user',
             password='secret'
         )
@@ -44,6 +52,7 @@ class BackendTestCase(TestCase):
     def test_login_user_admin(self):
         self.remote_user['product_permission'] = ['example_admin']
         student = self.User.objects.create_user(
+            id=1,
             username='user',
             password='secret'
         )

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -77,6 +77,6 @@ class BackendTestCase(TestCase):
 
 
 class CustomBackend(LabsUserBackend):
-    def post_authenticate(self, user, created):
+    def post_authenticate(self, user, created, dictionary):
         user.first_name = 'Modified'
         user.save()

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -9,7 +9,7 @@ class BackendTestCase(TestCase):
     def setUp(self):
         self.User = get_user_model()
         self.remote_user = {
-            'pennid': '1',
+            'pennid': 1,
             'first_name': 'First',
             'last_name': 'Last',
             'username': 'user',

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -2,6 +2,8 @@ from django.contrib import auth
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 
+from accounts.backends import LabsUserBackend
+
 
 class BackendTestCase(TestCase):
     def setUp(self):
@@ -67,3 +69,14 @@ class BackendTestCase(TestCase):
         self.assertEqual(len(self.User.objects.all()), 1)
         self.assertEqual(self.User.objects.all()[0].username, 'user')
         self.assertTrue(self.User.objects.all()[0].is_staff)
+
+    def test_custom_backend(self):
+        with self.settings(AUTHENTICATION_BACKENDS=('tests.test_backends.CustomBackend',)):
+            user = auth.authenticate(remote_user=self.remote_user)
+            self.assertEqual(user.first_name, 'Modified')
+
+
+class CustomBackend(LabsUserBackend):
+    def post_authenticate(self, user, created):
+        user.first_name = 'Modified'
+        user.save()

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -51,8 +51,7 @@ class CallbackViewTestCase(TestCase):
         self.User = get_user_model()
         self.mock_post = {
             'user': {
-                'major': 'Major',
-                'school': 'School',
+                'pennid': '1',
                 'first_name': 'First',
                 'last_name': 'Last',
                 'username': 'user',
@@ -70,6 +69,7 @@ class CallbackViewTestCase(TestCase):
 
     def test_inactive_user(self, mock_fetch_token, mock_post):
         self.User.objects.create_user(
+            id=1,
             username='user',
             password='secret',
             is_active=False


### PR DESCRIPTION
This PR:
* Migrates to using PennIDs as the primary form of authentication
* Adds a custom post-authentication method that is run after logging in a user.

Do not merge until pennlabs/platform#57 is merged and a workaround is set up for clubs