### PR TITLE
Fix Admin Model Register

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+0.4.2 (UNRELEASED)
+------------------
+* Fix: Register models from the default django admin
+
 0.4.1 (2019-11-10)
 ------------------
 * Feature: Update admin permissions on each login

--- a/accounts/admin.py
+++ b/accounts/admin.py
@@ -8,7 +8,10 @@ from accounts.settings import accounts_settings
 
 
 class LabsAdminSite(admin.AdminSite):
-
+    """
+    Custom admin site that redirects users to log in through platform
+    instead of logging in with a username and password
+    """
     def login(self, request, extra_context=None):
         if not request.user.is_authenticated:
             return redirect(reverse('accounts:login') + '?next=' + request.GET.get('next'))

--- a/accounts/admin.py
+++ b/accounts/admin.py
@@ -1,6 +1,4 @@
 from django.contrib import admin
-from django.contrib.auth.admin import GroupAdmin, UserAdmin
-from django.contrib.auth.models import Group, User
 from django.shortcuts import redirect
 from django.urls import reverse
 
@@ -19,6 +17,10 @@ class LabsAdminSite(admin.AdminSite):
 
 
 if accounts_settings.CUSTOM_ADMIN:
-    admin.site = LabsAdminSite()
-    admin.site.register(Group, GroupAdmin)
-    admin.site.register(User, UserAdmin)
+    """
+    Replace the default admin site with a custom one to log in users through platform.
+    Also copy all registered models from the default admin site
+    """
+    labs_admin = LabsAdminSite()
+    labs_admin._registry = admin.site._registry
+    admin.site = labs_admin


### PR DESCRIPTION
This PR fixes the issue where using the DLA admin would result in the removal of any 3rd party models from the django admin site.