### PR TITLE
Fix request variable shadowing

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -52,9 +52,9 @@ class CallbackView(View):
         # Use the access token to log in the user using information from platform
         platform = OAuth2Session(accounts_settings.CLIENT_ID, token=token)
         introspect_url = accounts_settings.PLATFORM_URL + '/accounts/introspect/'
-        request = platform.post(introspect_url, data={'token': token['access_token']})
-        if request.status_code == 200:  # Connected to platform successfully
-            user_props = request.json()['user']
+        platform_request = platform.post(introspect_url, data={'token': token['access_token']})
+        if platform_request.status_code == 200:  # Connected to platform successfully
+            user_props = platform_request.json()['user']
             user_props['token'] = token
             user_props['pennid'] = int(user_props['pennid'])
             user = auth.authenticate(request, remote_user=user_props)

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ deps =
     django20: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2
     django22: Django>=2.2
-    coverage
+    coverage==4.5.4
     unittest-xml-reporting
 
 [testenv:lint]


### PR DESCRIPTION
The response returned by the platform request overwrites the original request variable, which is needed when you do the `authenticate` and `login` calls.

This throws an `AttributeError` when you do `auth.login` because responses don't have session information.