### PR TITLE
Create user on IPC

### DIFF
--- a/accounts/middleware.py
+++ b/accounts/middleware.py
@@ -1,4 +1,5 @@
 import requests
+from django.contrib import auth
 from django.contrib.auth import get_user_model
 from django.http import HttpResponseForbidden
 
@@ -25,16 +26,25 @@ class OAuth2TokenMiddleware:
                 body = {"token": token}
                 headers = {"Authorization": "Bearer {}".format(token)}
                 try:
-                    data = requests.post(
+                    platform_request = requests.post(
                         url=accounts_settings.PLATFORM_URL + "/accounts/introspect/",
                         headers=headers,
                         data=body,
                     )
-                    if data.status_code == 200:  # Access token is valid
-                        data = data.json()
-                        user = User.objects.filter(id=int(data["user"]["pennid"]))
-                        if len(user) == 1:  # User has an account on this product
-                            request.user = user.first()
+                    if platform_request.status_code == 200:  # Access token is valid
+                        json = platform_request.json()
+                        user_props = json["user"]
+                        # TODO: maybe update access token if a local one does not exist
+                        # user_props["token"] = {
+                        #     "access_token": token,
+                        #     "refresh_token": "",
+                        #     "expires_in": json["exp"] - int(timezone.now().timestamp()),
+                        # }
+                        user = auth.authenticate(remote_user=user_props, tokens=False)
+                        if user:  # User authenticated successfully
+                            request.user = user
+                        else:  # Error occurred
+                            return HttpResponseForbidden()
                     else:  # Access token is invalid
                         return HttpResponseForbidden()
                 except requests.exceptions.RequestException:  # Can't connect to platform

--- a/accounts/middleware.py
+++ b/accounts/middleware.py
@@ -1,7 +1,7 @@
 import requests
 from django.contrib import auth
 from django.contrib.auth import get_user_model
-from django.http import HttpResponseForbidden
+from django.http import HttpResponseForbidden, HttpResponseServerError
 
 from accounts.settings import accounts_settings
 
@@ -44,7 +44,7 @@ class OAuth2TokenMiddleware:
                         if user:  # User authenticated successfully
                             request.user = user
                         else:  # Error occurred
-                            return HttpResponseForbidden()
+                            return HttpResponseServerError()
                     else:  # Access token is invalid
                         return HttpResponseForbidden()
                 except requests.exceptions.RequestException:  # Can't connect to platform

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -70,7 +70,6 @@ class CallbackView(View):
         if platform_request.status_code == 200:  # Connected to platform successfully
             user_props = platform_request.json()["user"]
             user_props["token"] = token
-            user_props["pennid"] = int(user_props["pennid"])
             user = auth.authenticate(request, remote_user=user_props)
             if user:
                 auth.login(request, user)

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock, patch
 import requests
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
+from django.http import HttpResponseServerError
 from django.test import TestCase
 from django.urls import reverse
 
@@ -133,3 +134,12 @@ class TestViewTestCase(TestCase):
         self.headers["HTTP_AUTHORIZATION"] = "Bearer abc123"
         response = self.client.get(reverse("test"), **self.headers)
         self.assertEqual(403, response.status_code)
+
+    @patch("accounts.middleware.auth.authenticate")
+    def test_authorization_header_valid_server_error(self, mock_authenticate, mock_request):
+        mock_authenticate.return_value = None
+        mock_request.return_value.status_code = 200
+        mock_request.return_value.json.return_value = self.valid_response
+        self.headers["HTTP_AUTHORIZATION"] = "Bearer abc123"
+        response = self.client.get(reverse("test"), **self.headers)
+        self.assertEqual(500, response.status_code)

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -3,7 +3,6 @@ from unittest.mock import Mock, patch
 import requests
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
-from django.http import HttpResponseServerError
 from django.test import TestCase
 from django.urls import reverse
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -65,9 +65,9 @@ class CallbackViewTestCase(TestCase):
         session["next"] = self.redirect
         session.save()
         self.User = get_user_model()
-        self.mock_post = {
+        self.mock_post = {  # Response from introspect
             "user": {
-                "pennid": "1",
+                "pennid": 1,
                 "first_name": "First",
                 "last_name": "Last",
                 "username": "user",
@@ -78,7 +78,7 @@ class CallbackViewTestCase(TestCase):
         }
 
     def test_active_user(self, mock_fetch_token, mock_post):
-        mock_fetch_token.return_value = {
+        mock_fetch_token.return_value = {  # Response from token
             "access_token": "abc",
             "refresh_token": "123",
             "expires_in": 100,


### PR DESCRIPTION
This PR creates a local user when receiving an IPC request if one does not exist. It uses the existing backend to create/update the user's profile (except access and refresh tokens).