### PR TITLE
Optional Sentry Logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+0.7.0 (2020-07-28)
+------------------
+* Add sentry logging
+* Add failback default with next parameters
+
 0.6.1 (2020-02-21)
 ------------------
 * Refactor user permissions with updated Platform

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -26,6 +26,12 @@ class LoginView(View):
     def get(self, request):
         return_to = request.GET.get("next", "/")
         if not return_to.startswith("/"):
+            try:
+                from sentry_sdk import capture_message
+
+                capture_message(f"Invalid next parameter: {return_to}", level="error")
+            except ImportError:
+                pass
             return HttpResponseBadRequest("Invalid next parameter")
         request.session["next"] = return_to
         if not request.user.is_authenticated:

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1,6 +1,5 @@
 from django.contrib import auth
 from django.http import HttpResponseServerError
-from django.http.response import HttpResponseBadRequest
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.views import View

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -36,7 +36,7 @@ class LoginView(View):
         return_to = request.GET.get("next", "/")
         if not return_to.startswith("/"):
             invalid_next(return_to)
-            return HttpResponseBadRequest("Invalid next parameter")
+            return_to = "/"
         request.session["next"] = return_to
         if not request.user.is_authenticated:
             platform = OAuth2Session(
@@ -63,7 +63,7 @@ class CallbackView(View):
         return_to = request.session.pop("next", "/")
         if not return_to.startswith("/"):
             invalid_next(return_to)
-            return HttpResponseBadRequest("Invalid next parameter")
+            return_to = "/"
         state = request.session.pop("state")
         platform = OAuth2Session(
             accounts_settings.CLIENT_ID, redirect_uri=get_redirect_uri(request), state=state
@@ -100,5 +100,5 @@ class LogoutView(View):
         return_to = request.GET.get("next", "/")
         if not return_to.startswith("/"):
             invalid_next(return_to)
-            return HttpResponseBadRequest("Invalid next parameter")
+            return_to = "/"
         return redirect(return_to)

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
     py36-django{21,22,30,master},
     py37-django{21,22,30,master},
     py38-django{21,22,30,master},
+    sentry-django30,
 
 [testenv]
 commands = pytest --cov=accounts --cov-append --junitxml=test-results/tests.xml
@@ -16,6 +17,7 @@ deps =
     django22: Django>=2.2,<3.0
     django30: Django>3.0
     djangomaster: https://github.com/django/django/archive/master.tar.gz
+    sentry: sentry-sdk
     coverage
     pytest
     pytest-cov


### PR DESCRIPTION
This PR enables logging to sentry with an invalid `next` parameter if `sentry-sdk` is installed.