### PR TITLE
Fix IntegrityError Bug for Platform Auth Groups

### DIFF
--- a/.github/workflows/cdkactions_build-and-publish.yaml
+++ b/.github/workflows/cdkactions_build-and-publish.yaml
@@ -13,7 +13,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - 3.6
           - 3.7
           - 3.8
           - 3.9

--- a/.github/workflows/cdkactions_build-and-publish.yaml
+++ b/.github/workflows/cdkactions_build-and-publish.yaml
@@ -13,6 +13,7 @@ jobs:
     strategy:
       matrix:
         python-version:
+          - 3.6
           - 3.7
           - 3.8
           - 3.9

--- a/.github/workflows/cdkactions_build-and-publish.yaml
+++ b/.github/workflows/cdkactions_build-and-publish.yaml
@@ -13,7 +13,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - 3.7
           - 3.8
           - 3.9
     steps:

--- a/accounts/backends.py
+++ b/accounts/backends.py
@@ -59,7 +59,7 @@ class LabsUserBackend(RemoteUserBackend):
                 user.is_staff = False
                 user.is_superuser = False
 
-        # Update groups: first clear them from existing groups then add them to new groups
+        # First disassociates user with platform groups, then loads in new groups
         user.groups.remove(*user.groups.filter(name__startswith="platform_"))
         for group_name in remote_user["groups"]:
             group, _ = Group.objects.get_or_create(name=f"platform_{group_name}")

--- a/accounts/backends.py
+++ b/accounts/backends.py
@@ -60,7 +60,7 @@ class LabsUserBackend(RemoteUserBackend):
                 user.is_superuser = False
 
         # Update groups: first clear them from existing groups then add them to new groups
-        user.groups.filter(name__startswith="platform_").clear()
+        user.groups.remove(user.groups.filter(name__startswith="platform_"))
         for group_name in remote_user["groups"]:
             group, _ = Group.objects.get_or_create(name=f"platform_{group_name}")
             user.groups.add(group)

--- a/accounts/backends.py
+++ b/accounts/backends.py
@@ -59,8 +59,8 @@ class LabsUserBackend(RemoteUserBackend):
                 user.is_staff = False
                 user.is_superuser = False
 
-        # Update groups: first remove them from existing groups then add them to new groups
-        user.groups.filter(name__startswith="platform_").delete()
+        # Update groups: first clear them from existing groups then add them to new groups
+        user.groups.filter(name__startswith="platform_").clear()
         for group_name in remote_user["groups"]:
             group, _ = Group.objects.get_or_create(name=f"platform_{group_name}")
             user.groups.add(group)

--- a/accounts/backends.py
+++ b/accounts/backends.py
@@ -60,7 +60,7 @@ class LabsUserBackend(RemoteUserBackend):
                 user.is_superuser = False
 
         # Update groups: first clear them from existing groups then add them to new groups
-        user.groups.remove(user.groups.filter(name__startswith="platform_"))
+        user.groups.remove(*user.groups.filter(name__startswith="platform_"))
         for group_name in remote_user["groups"]:
             group, _ = Group.objects.get_or_create(name=f"platform_{group_name}")
             user.groups.add(group)

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,6 @@
 isolated_build = true
 envlist =
     lint,
-    py37-django{22,30,31,32},
     py38-django{22,30,31,32},
     py39-django{22,30,31,32},
     sentry-django{30,31},
@@ -51,6 +50,5 @@ django_find_project = false
 
 [gh-actions]
 python =
-    3.7: py37
     3.8: py38, lint, sentry
     3.9: py39

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ envlist =
     sentry-django{30,31},
 
 [testenv]
-allowlist_externals = poetry
+whitelist_externals = poetry
 commands =
     poetry install
     poetry run pytest --cov=accounts {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 isolated_build = true
 envlist =
     lint,
-    py38-django{22,30,31,main},
-    py39-django{22,30,31,main},
+    py38-django{22,30,31,32},
+    py39-django{22,30,31,32},
     sentry-django{30,31},
 
 [testenv]
@@ -18,7 +18,7 @@ setenv =
 deps =
     django30: Django>=3.0,<3.1
     django31: Django>3.1
-    djangomain: https://github.com/django/django/archive/main.tar.gz
+    django32: Django>3.2
     sentry: sentry-sdk
 
 [testenv:lint]

--- a/tox.ini
+++ b/tox.ini
@@ -50,6 +50,7 @@ django_find_project = false
 
 [gh-actions]
 python =
+    3.6: py36
     3.7: py37
     3.8: py38, lint, sentry
     3.9: py39

--- a/tox.ini
+++ b/tox.ini
@@ -50,7 +50,6 @@ django_find_project = false
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38, lint, sentry
     3.9: py39

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 isolated_build = true
 envlist =
     lint,
+    py37-django{22,30,31,32},
     py38-django{22,30,31,32},
     py39-django{22,30,31,32},
     sentry-django{30,31},

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ envlist =
     sentry-django{30,31},
 
 [testenv]
-whitelist_externals = poetry
+allowlist_externals = poetry
 commands =
     poetry install
     poetry run pytest --cov=accounts {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 isolated_build = true
 envlist =
     lint,
-    python3.8-django{22,30,31,main},
-    python3.9-django{22,30,31,main},
+    py38-django{22,30,31,main},
+    py39-django{22,30,31,main},
     sentry-django{30,31},
 
 [testenv]
@@ -50,7 +50,6 @@ django_find_project = false
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38, lint, sentry
     3.9: py39

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 isolated_build = true
 envlist =
     lint,
-    py38-django{22,30,31,main},
-    py39-django{22,30,31,main},
+    python3.8-django{22,30,31,main},
+    python3.9-django{22,30,31,main},
     sentry-django{30,31},
 
 [testenv]
@@ -11,18 +11,18 @@ whitelist_externals = poetry
 commands =
     poetry install
     poetry run pytest --cov=accounts {posargs}
-setenv = 
+setenv =
     DJANGO_SETTINGS_MODULE = tests.settings
     PYTHONPATH = {toxinidir}
     PYTHONWARNINGS = all
-deps = 
+deps =
     django30: Django>=3.0,<3.1
     django31: Django>3.1
     djangomain: https://github.com/django/django/archive/main.tar.gz
     sentry: sentry-sdk
 
 [testenv:lint]
-commands = 
+commands =
     poetry install
     poetry run flake8 .
     poetry run isort -c .


### PR DESCRIPTION
Attempt to fix [Sentry error](https://sentry.io/organizations/penn-labs/issues/2968539773/?project=6171896&referrer=project-issue-stream) that has been plaguing Mobile's bug list for over a year.

Instead of calling `delete()` which deletes objects from the database, we instead call `remove` to disassociate the `auth_user` group foreign key, but keep the `Group` object in the database.

- Removed Python 3.6. Addressing reasoning [here](https://github.com/actions/setup-python/issues/544) and [here](https://peps.python.org/pep-0494/#lifespan)
- Removed Python 3.7 check because TOML file specifies `django-labs-accounts` depends on `Python >=3.8`
- Removed `django-main` requirement because current Django package requires `Python>=3.10`
- Added Django 3.2 check