### PR TITLE
Add nix Flake for reproducible building and development environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ dist/
 __pycache__/
 .tox
 test-results/
+
+# Nix
+result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,46 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1738734093,
+        "narHash": "sha256-UEYOKfXXKU49fR7dGB05As0s2pGbLK4xDo48Qtdm7xs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5b2753b0356d1c951d7a3ef1d086ba5a71fff43c",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "pyproject-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1738204167,
+        "narHash": "sha256-J5M2sj3x4ocM93shScT/3Z4XWHZhwwW1NyQK+C+8Mys=",
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "rev": "0d9f4b90cee1b5c5d6c142ef22de1e246e003ccc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "pyproject-nix": "pyproject-nix"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,67 @@
+{
+  description = "django-labs-accounts for Penn Labs";
+
+  inputs = {
+      pyproject-nix = {
+        url = "github:pyproject-nix/pyproject.nix";
+        inputs.nixpkgs.follows = "nixpkgs";
+      };
+  };
+
+  outputs =
+    { nixpkgs, pyproject-nix, ... }:
+    let
+      # Loads pyproject.toml into a high-level project representation
+      # Do you notice how this is not tied to any `system` attribute or package sets?
+      # That is because `project` refers to a pure data representation.
+      project = pyproject-nix.lib.project.loadPoetryPyproject {
+        # Read & unmarshal pyproject.toml relative to this project root.
+        # projectRoot is also used to set `src` for renderers such as buildPythonPackage.
+        projectRoot = ./.;
+      };
+
+      # This example is only using x86_64-linux
+      pkgs = nixpkgs.legacyPackages.x86_64-linux;
+
+      # We are using the default nixpkgs Python3 interpreter & package set.
+      #
+      # This means that you are purposefully ignoring:
+      # - Version bounds
+      # - Dependency sources (meaning local path dependencies won't resolve to the local path)
+      #
+      # To use packages from local sources see "Overriding Python packages" in the nixpkgs manual:
+      # https://nixos.org/manual/nixpkgs/stable/#reference
+      #
+      # Or use an overlay generator such as uv2nix:
+      # https://github.com/pyproject-nix/uv2nix
+      python = pkgs.python312.override {
+          packageOverrides = self: prev: {
+              django = prev.django_5;
+          };
+      };
+    in
+    {
+      # Create a development shell containing dependencies from `pyproject.toml`
+      devShells.x86_64-linux.default =
+        let
+          # Returns a function that can be passed to `python.withPackages`
+          arg = project.renderers.withPackages { inherit python; extraPackages = (ps: [ ps.pytest ]); };
+
+          # Returns a wrapped environment (virtualenv like) with all our packages
+          pythonEnv = python.withPackages arg;
+
+        in
+        # Create a devShell like normal.
+        pkgs.mkShell { packages = [ pythonEnv pkgs.poetry ]; };
+
+      # Build our package using `buildPythonPackage
+      packages.x86_64-linux.default =
+        let
+          # Returns an attribute set that can be passed to `buildPythonPackage`.
+          attrs = project.renderers.buildPythonPackage { inherit python; };
+        in
+        # Pass attributes to buildPythonPackage.
+        # Here is a good spot to add on any missing or custom attributes.
+        python.pkgs.buildPythonPackage attrs;
+    };
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ packages = [
 [tool.poetry.dependencies]
 python = "^3.11"
 Django = "^5.0.2"
-requests-oauthlib = "^1.3.1"
+requests-oauthlib = "^2.0.0"
 requests = "^2.0.0"
 djangorestframework = "^3.14.0"
 six = "^1.16.0"


### PR DESCRIPTION
I'm just learning flakes, but as far as I can tell, this is set up properly. It works for development in Penn Mobile: https://github.com/clay53/penn-mobile/tree/9cad10aed61f9d1a241768a3fd8aaff5fb4906ba . I had to bump request-oauthlib to 2.0.0 because of the Django requirement iirc, but as far as I can tell, everything is still working. Should be tested properly, though. I'm not sure which tests were passing before this change since I can't test that, so I'm not sure myself.