### PR TITLE
Fix analytics to work with Django ViewSet actions

### DIFF
--- a/analytics/analytics.py
+++ b/analytics/analytics.py
@@ -5,12 +5,12 @@ from concurrent.futures import ThreadPoolExecutor
 from enum import IntEnum
 from string import Template
 from typing import Any, Callable, List, Optional, Type
+from functools import wraps
 
 from django.utils import timezone
 from django.utils.termcolors import colorize
 from requests import Session
 from rest_framework.views import APIView
-from functools import wraps
 
 from analytics.entries import (
     AnalyticsEntry,

--- a/analytics/analytics.py
+++ b/analytics/analytics.py
@@ -10,6 +10,7 @@ from django.utils import timezone
 from django.utils.termcolors import colorize
 from requests import Session
 from rest_framework.views import APIView
+from functools import wraps
 
 from analytics.entries import (
     AnalyticsEntry,
@@ -151,6 +152,7 @@ class AnalyticsRecorder(AnalyticsSubmitter):
         def decorator(func):
             explicit_args_names = func.__code__.co_varnames[: func.__code__.co_argcount]
 
+            @wraps(func)
             def wrapped_func(*args, **kwargs):
                 explicit_args = analytics_recorder._extract_explicit_args(
                     explicit_args_names, args, kwargs
@@ -205,6 +207,7 @@ class AnalyticsRecorder(AnalyticsSubmitter):
                     "UnaryFuncEntry can only be used with functions with a single argument"
                 )
 
+            @wraps(func)
             def wrapped_func(*args, **kwargs):
                 explicit_args = analytics_recorder._extract_explicit_args(
                     explicit_args_names, args, kwargs

--- a/analytics/analytics.py
+++ b/analytics/analytics.py
@@ -3,9 +3,9 @@ import time
 from abc import ABC, abstractmethod
 from concurrent.futures import ThreadPoolExecutor
 from enum import IntEnum
+from functools import wraps
 from string import Template
 from typing import Any, Callable, List, Optional, Type
-from functools import wraps
 
 from django.utils import timezone
 from django.utils.termcolors import colorize


### PR DESCRIPTION
**Key Change**
* Added @wraps(func) to record_api_function and record_function methods

**Explanation for Error**
When implementing analytics on Penn Clubs, the following error was thrown.

`AssertionError: Expected function (wrapped_func) to match its attribute name (email_blast)`
* The reason for this error is that in a ViewSet, Django finds custom endpoints with @action. After inspecting each extra action, Django asserts that the callable's __name__ matches the attribute name on the class. But, the analytics decorator (as it currently is written) returns a wrapper named wrapped_func and raised the error.

**Explanation for Fix**
* Adding @wraps(func) to the inner wrapper in both functions preserves the original function's metadata (notably, __name__ in this case). 
* The reason this error was not encountered when implementing Penn Mobile analytics since Penn Mobile uses APIView / ListAPIView classes. Django does not check the callable's __name__ for APIView methods so the fact that the decorator returns wrapped_func does not raise an error.
